### PR TITLE
Add support for optionally specifying encoding

### DIFF
--- a/jinja2_base64_filters/jinja2_base64_filters.py
+++ b/jinja2_base64_filters/jinja2_base64_filters.py
@@ -13,7 +13,7 @@ class Base64Filters(Extension):
         environment.filters["b64decode"] = base64decode
 
 
-def base64encode(string):
+def base64encode(string, encoding="utf-8"):
     """
     args:
         string (str)
@@ -22,14 +22,14 @@ def base64encode(string):
     """
     # b64encode take a byte-like object as input so we need to encode our string(str)
     # b64encode returns a byte-like object so we convert it to a str
-    return base64.b64encode(string.encode()).decode()
+    return base64.b64encode(string.encode(encoding)).decode()
 
 
-def base64decode(string):
+def base64decode(string, encoding="utf-8"):
     """
     args:
         string (str)
     returns:
         string (str)
     """
-    return base64.b64decode(string.encode()).decode()
+    return base64.b64decode(string.encode()).decode(encoding)


### PR DESCRIPTION
When generating base64 encoded passwords for Windows autounattend.xml answer files, the text should be UTF-16LE encoded. This PR allows the filter user to optionally specify which encoding to use, falling back to UTF-8 as a default.

Example usage:
```
{% set mystr = "foo a bar" %}
{{ mystr | b64encode("utf-16le") }}
```
This should produce the bytes `ZgBvAG8AIABhACAAYgBhAHIA`, versus `Zm9vIGEgYmFy`, which could be produced using the default UTF-8 encoding.